### PR TITLE
False Positive - remove analytics.twitter.com

### DIFF
--- a/src/bg_scripts/adblock_scripts/ad_domains.js
+++ b/src/bg_scripts/adblock_scripts/ad_domains.js
@@ -11211,7 +11211,6 @@ var adDomains = [
     "*://*.deviceidshare.twitch.tv/*",
     "*://*.ads.twitter.com/*",
     "*://*.ads-bidder-api.twitter.com/*",
-    "*://*.analytics.twitter.com/*",
     "*://*.scribe.twitter.com/*",
     "*://*.u-ad.info/*",
     "*://*.lightstep-collector.api.ua.com/*",


### PR DESCRIPTION
analytics.twitter.com is required for links in tweets, and also it's a page where Twitter users can view their account stats.